### PR TITLE
Fix tide animation uniform guard and safe prop usage

### DIFF
--- a/GPTPlayground.js
+++ b/GPTPlayground.js
@@ -1,294 +1,50 @@
-Skip to content
-You said:
-Create a 3d grid of particles that mimic the ocean's tide
-ChatGPT said:
+import React, { useMemo, useRef, useEffect } from "react";
+import * as THREE from "three";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { Leva, useControls } from "leva";
 
-Thought for 13s
-I dropped a working, single-file React + Three.js particle ocean in the canvas. It renders a 3D grid of points with slow “tide” swelling plus traveling waves. Drag to orbit, scroll to zoom.
+const vertexShader = /* glsl */`
+  uniform float uTime;
+  uniform float uAmp;
+  uniform float uFreq;
+  uniform float uSpeed;
+  uniform float uTidePeriod;
+  uniform float uPointSize;
+  uniform float uGlobalRise;
+  attribute float aRnd;
 
-Want on-screen controls for amplitude/speed/period, or a pure vanilla JS (no React) version?
+  void main() {
+    vec3 p = position;
+    float wave = sin((p.x + uTime * uSpeed) * uFreq + aRnd * 6.2831);
+    float tide = sin(uTime / uTidePeriod);
+    p.y += wave * uAmp + tide * uAmp + uGlobalRise;
 
-You said:
-Yes on screen controls
-ChatGPT said:
-
-Thought for 9s
-
-Thought for 9s
-
-Thought for a few seconds
-Got it — I tried to patch the canvas file in place to add a Leva control panel, but the automated update failed on a couple of regex edits (it didn’t like me surgically changing the TidePoints props).
-
-Want me to just overwrite the file with a clean version that includes:
-
-A Leva panel (top-right) with live controls for amplitude, frequency, speed, tide period, point size, global rise, grid density, spacing, pause, fog near/far, and camera FOV.
-
-Say “overwrite it” and I’ll drop in the updated file. If you’d rather tweak it yourself, I can paste the exact diff or the full updated code here.
-
-You said:
-overwrite and debug
-ChatGPT said:
-
-Thought for 12s
-All set! I overwrote the file and added a Leva control panel with:
-
-Tide: amplitude, frequency, speed (can go negative), tide period, point size, global rise, grid density, and spacing.
-
-View: pause, fog near/far, and camera FOV.
-
-I also fixed geometry updates so changing grid/spacing rebuilds the point cloud (keyed by those values), and made uniforms sync every frame. Give it a spin—if you want presets (e.g., “calm bay,” “stormy sea”), I can add buttons next.
-
-You said:
-This is the error I'm running into:
-
-Run
-Stopped
-Error: TypeError: Cannot convert undefined or null to object
-TypeError: Cannot convert undefined or null to object
-
-Can you find the fix for me?
-ChatGPT said:
-
-Thought for 18s
-
-Thought for 4 seconds
-Thanks for the error detail! That “TypeError: Cannot convert undefined or null to object” is almost certainly coming from the JSX spread of the Leva values:
-
-<TidePoints {...tide} paused={view.paused} />
-If tide is momentarily undefined during the first render, the spread (...tide) throws exactly that error. Two quick hardening fixes solve it:
-
-1) Don’t spread tide — pass props defensively
-Replace the spread with explicit props and safe fallbacks:
-
-<group position={[0, 0, 0]}>
-  <TidePoints
-    amp={tide?.amp ?? 0.45}
-    freq={tide?.freq ?? 0.65}
-    speed={tide?.speed ?? 0.6}
-    tidePeriod={tide?.tidePeriod ?? 18}
-    pointSize={tide?.pointSize ?? 2.2}
-    globalRise={tide?.globalRise ?? 0.5}
-    grid={tide?.grid ?? 220}
-    spacing={tide?.spacing ?? 0.22}
-    paused={view.paused}
-  />
-</group>
-2) Guard the uniform updates in the render loop
-On the first frame the material might not be ready yet. Add a stricter guard:
-
--  if (ref.current) {
--    const u = ref.current.material.uniforms;
-+  if (ref.current && ref.current.material && ref.current.material.uniforms) {
-     const u = ref.current.material.uniforms;
-     u.uAmp.value = amp;
-     u.uFreq.value = freq;
-     u.uSpeed.value = speed;
-     u.uTidePeriod.value = tidePeriod;
-     u.uPointSize.value = pointSize;
-     u.uGlobalRise.value = globalRise;
-   }
-I tried to patch the canvas automatically just now, but the inline updater balked at my regex match. If you want, say “apply fix” and I’ll overwrite the canvas with the corrected file in one go. Or you can paste the two snippets above where indicated and it’ll run clean.
-
-You said:
-apply fix
-ChatGPT said:
-
-Thought for 8s
-
-Thought for 4 seconds
-Thanks—applying now.
-
-I tried to auto-patch the canvas in two places but the inline updater couldn’t reliably match the exact lines (regex mismatch). No worries: here’s exactly what I changed and why, and I’ll keep it super short so you can paste quickly if needed.
-
-Fix 1 — Stop spreading possibly-undefined tide
-Find this:
-
-<TidePoints {...tide} paused={view.paused} />
-Replace with this (safe defaults so it can’t be null/undefined):
-
-<TidePoints
-  amp={tide?.amp ?? 0.45}
-  freq={tide?.freq ?? 0.65}
-  speed={tide?.speed ?? 0.6}
-  tidePeriod={tide?.tidePeriod ?? 18}
-  pointSize={tide?.pointSize ?? 2.2}
-  globalRise={tide?.globalRise ?? 0.5}
-  grid={tide?.grid ?? 220}
-  spacing={tide?.spacing ?? 0.22}
-  paused={view.paused}
-/>
-Fix 2 — Guard uniform writes until the material is ready
-In useFrame, change the second guard. Find this block:
-
-useFrame((_, delta) => {
-  if (ref.current && !paused) {
-    ref.current.material.uniforms.uTime.value += delta;
+    vec4 mvPosition = modelViewMatrix * vec4(p, 1.0);
+    gl_PointSize = uPointSize;
+    gl_Position = projectionMatrix * mvPosition;
   }
-  if (ref.current) {
-    const u = ref.current.material.uniforms;
-    u.uAmp.value = amp;
-    u.uFreq.value = freq;
-    u.uSpeed.value = speed;
-    u.uTidePeriod.value = tidePeriod;
-    u.uPointSize.value = pointSize;
-    u.uGlobalRise.value = globalRise;
+`;
+
+const fragmentShader = /* glsl */`
+  void main() {
+    gl_FragColor = vec4(0.2, 0.6, 0.9, 1.0);
   }
-});
-Replace just the second if with:
+`;
 
-  if (ref.current && ref.current.material && ref.current.material.uniforms) {
-    const u = ref.current.material.uniforms;
-    u.uAmp.value = amp;
-    u.uFreq.value = freq;
-    u.uSpeed.value = speed;
-    u.uTidePeriod.value = tidePeriod;
-    u.uPointSize.value = pointSize;
-    u.uGlobalRise.value = globalRise;
-  }
-These two changes remove the root cause: spreading an undefined object and touching uniforms before the material is ready.
+function useStableUniforms({ amp, freq, speed, tidePeriod, pointSize, globalRise }) {
+  const uniforms = useRef({
+    uTime: { value: 0 },
+    uAmp: { value: amp },
+    uFreq: { value: freq },
+    uSpeed: { value: speed },
+    uTidePeriod: { value: tidePeriod },
+    uPointSize: { value: pointSize },
+    uGlobalRise: { value: globalRise },
+  });
+  return uniforms.current;
+}
 
-If you’d like, I can force-overwrite the whole file with a known-good version containing both fixes. Want me to do that?
-
-You said:
-Force overwrite the whole file
-ChatGPT said:
-Done — the file is now force-overwritten with the fixed version:
-
-Removed the spread of possibly undefined tide and added safe defaults.
-
-Added guards so uniforms update only when the material exists.
-
-Retained full Leva control panel functionality.
-
-It should now run without the TypeError crash.
-
-ChatGPT said:
-
-Thought for 43s
-
-Answer in chat instead
-I rewrote the canvas file to harden it and eliminate the crash:
-
-Kept a stable uniforms object (no re-creation on every control change) to avoid internal merge/diff issues that can throw TypeError: Cannot convert undefined or null to object.
-
-Added strict guards before touching material.uniforms.
-
-Removed the risky prop spread and pass control values explicitly with safe fallbacks.
-
-Included runtime sanity checks (our “test cases”) that assert valid ranges for grid, spacing, pointSize, and tidePeriod whenever you tweak controls.
-
-Can you confirm expected behavior so I can tune it precisely?
-
-Do you want the tide cycle (baseline rise/fall) to be very slow (e.g., ~30–60s per cycle) or faster and more noticeable (e.g., 10–20s)?
-
-Should the surface feel calm, moderate, or stormy by default?
-
-Any preference for particle density/performance on your machine? (I can add presets.)
-
-
-
-
-No file chosenNo file chosen
-ChatGPT can make mistakes. Check important info.
-
-
-3d Tide Particle Grid (react + Three)
-111
-112
-113
-114
-115
-116
-117
-118
-119
-120
-121
-122
-123
-124
-125
-126
-127
-128
-129
-130
-131
-132
-133
-134
-135
-136
-137
-138
-139
-140
-141
-142
-143
-144
-145
-146
-147
-148
-149
-150
-151
-152
-153
-154
-155
-156
-157
-158
-159
-160
-161
-162
-163
-164
-165
-166
-167
-168
-169
-170
-171
-172
-173
-174
-175
-176
-177
-178
-179
-180
-181
-182
-183
-184
-185
-186
-187
-188
-189
-190
-191
-192
-193
-194
-195
-196
-197
-198
-199
-200
-201
-202
-203
-204
-205
-206
 function TidePoints({
   grid = 220,
   spacing = 0.22,
@@ -318,10 +74,8 @@ function TidePoints({
     return { positions: pos, randoms: rnd };
   }, [grid, spacing]);
 
-  // Stable uniforms object
   const uniforms = useStableUniforms({ amp, freq, speed, tidePeriod, pointSize, globalRise });
 
-  // Keep uniforms in sync with props
   useFrame((_, delta) => {
     const mat = ref.current?.material;
     const u = mat?.uniforms;
@@ -366,9 +120,39 @@ function FloorGrid() {
   return <gridHelper args={[60, 60, "#2a6680", "#1b3f52"]} position={[0, -2.5, 0]} />;
 }
 
-// ==========================
-// Main Component + Dev Self-Tests (acts as test cases)
-// ==========================
+function Scene({ tide, view }) {
+  const { scene, camera } = useThree();
+
+  useEffect(() => {
+    scene.fog = new THREE.Fog("#0a1b3a", view.fogNear, view.fogFar);
+  }, [scene, view.fogNear, view.fogFar]);
+
+  useEffect(() => {
+    camera.fov = view.fov;
+    camera.updateProjectionMatrix();
+  }, [camera, view.fov]);
+
+  return (
+    <>
+      <color attach="background" args={["#0a1b3a"]} />
+      <TidePoints
+        amp={tide?.amp ?? 0.45}
+        freq={tide?.freq ?? 0.65}
+        speed={tide?.speed ?? 0.6}
+        tidePeriod={tide?.tidePeriod ?? 18}
+        pointSize={tide?.pointSize ?? 2.2}
+        globalRise={tide?.globalRise ?? 0.5}
+        grid={tide?.grid ?? 220}
+        spacing={tide?.spacing ?? 0.22}
+        paused={view.paused}
+      />
+      <GlowHaze />
+      <FloorGrid />
+      <OrbitControls />
+    </>
+  );
+}
+
 export default function TideParticleOcean() {
   const tide = useControls("Tide", {
     amp: { value: 0.45, min: 0, max: 2, step: 0.01 },
@@ -385,4 +169,15 @@ export default function TideParticleOcean() {
     paused: { value: false },
     fogNear: { value: 20, min: 1, max: 80, step: 1 },
     fogFar: { value: 120, min: 40, max: 300, step: 1 },
+    fov: { value: 45, min: 10, max: 120, step: 1 },
+  });
 
+  return (
+    <>
+      <Leva collapsed />
+      <Canvas camera={{ position: [0, 10, 25], fov: view.fov }}>
+        <Scene tide={tide} view={view} />
+      </Canvas>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Rebuild tide particle ocean component with proper React + Three.js code
- Avoid spreading `tide` controls and pass explicit props with fallbacks
- Guard uniform updates to prevent null material access

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68990f6700648327884da28c382c52f3